### PR TITLE
Fix building on Linux and building in debug mode

### DIFF
--- a/ext_src/voxelizer/voxelizer.h
+++ b/ext_src/voxelizer/voxelizer.h
@@ -664,9 +664,9 @@ vx_aabb_t vx__aabb_merge(vx_aabb_t* a, vx_aabb_t* b)
 
 size_t vx__vertex_hash(vx_vertex_t pos, size_t n)
 {
-    size_t a = (size_t)(pos.x * 73856093);
-    size_t b = (size_t)(pos.y * 19349663);
-    size_t c = (size_t)(pos.z * 83492791);
+    size_t a = (size_t)(pos.x * 73856093.0F);
+    size_t b = (size_t)(pos.y * 19349663.0F);
+    size_t c = (size_t)(pos.z * 83492791.0F);
 
     return (a ^ b ^ c) % n;
 }

--- a/src/filters/genland.cpp
+++ b/src/filters/genland.cpp
@@ -137,7 +137,6 @@ static unsigned char noisep[512], noisep15[512];
 static void noiseinit()
 {
     long i, j, k;
-    float f;
 
     for (i = 256 - 1; i >= 0; i--)
         noisep[i] = i;
@@ -221,14 +220,13 @@ extern "C" void generate_tomland_terrain(volume_t *volume, genland_settings_t *s
     double octaveAmplitudes[settings->num_octaves];
     // Base height samples and corrected height samples (for normal calculation)
     double baseSamples[3], correctedSamples[3];
-    double unusedDot, normalX, normalY, normalZ;
+    double normalX, normalY, normalZ;
     // Ground color components (red, green, blue)
     double groundRed, groundGreen, groundBlue;
     // Temporary variable used in shadow calculations
     float shadowCheckValue;
     // Loop indices and temporary variables
     long octaveIndex, shadowIter, pixelX, pixelY, globalIndex, octave, progressPercent, maxAmbient, colorIndex;
-    long palette[256]; // Unused palette array
     // Lookup table for noise mask values per octave
     long maskLUT[settings->num_octaves];
 

--- a/src/filters/genland.cpp
+++ b/src/filters/genland.cpp
@@ -21,7 +21,6 @@
 
 #include <memory.h>
 #include <math.h>
-#include <conio.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -91,7 +90,7 @@ static void process_voxel_data(volume_t *volume, genland_settings_t *settings, v
 // Noise algo based on "Improved Perlin Noise" by Ken Perlin
 // http://mrl.nyu.edu/~perlin/
 
-static __forceinline float fgrad(long h, float x, float y, float z)
+static inline float fgrad(long h, float x, float y, float z)
 {
     switch (h) // h masked before call (h&15)
     {

--- a/src/formats/gltf.c
+++ b/src/formats/gltf.c
@@ -383,7 +383,6 @@ static void create_palette_texture(
     image->buffer_view = buffer_view;
     texture = add_item(g->data, textures);
     texture->image = image;
-    free(png);
 }
 
 static void gltf_export(const image_t *img, const char *path,

--- a/src/goxel.c
+++ b/src/goxel.c
@@ -28,7 +28,7 @@
 
 // The global goxel instance.
 goxel_t goxel = {};
-double time = 0.0;
+double g_time = 0.0;
 
 static void (*post_reset_func)() = NULL;
 
@@ -694,8 +694,8 @@ void goxel_mouse_in_view(const float viewport[4], const inputs_t *inputs,
     float p[3], n[3];
     camera_t *camera = get_camera();
     double frameTime = get_unix_time();
-    double deltaTime = frameTime - time;
-    time = frameTime;
+    double deltaTime = frameTime - g_time;
+    g_time = frameTime;
 
     painter_t painter = goxel.painter;
     gesture_update(goxel.gestures_count, goxel.gestures,

--- a/src/main.c
+++ b/src/main.c
@@ -31,6 +31,13 @@ static float        g_scale = 1;
 
 static void on_glfw_error(int code, const char *msg)
 {
+    // Discard GLFW error 65548
+    // This error indicates that setting the window icon was unsuccessful,
+    // which is not fatal and normal on Wayland.
+    if (code == 65548) {
+        return;
+    }
+
     fprintf(stderr, "glfw error %d (%s)\n", code, msg);
     assert(false);
 }


### PR DESCRIPTION
- Removed unused variables declarations
- Removed non-standard `conio.h` import
- Remove `free(png)` (we were never actually freeing any data, but an enum value, which doesn't make sense)
- Make the `voxelizer.h` magic values in `vx__vertex_hash` floats to avoid implicit conversions
- Rename `time` global in goxel.c to `g_time` to avoid conflicting with the POSIX `time()` declaration
- Ignore GLFW error 65548 (non-fatal, it happens when you try to set the window icon on a platform that doesn't support it, such as Wayland)
