### PR TITLE
feat(export_panel): remember last export path

### DIFF
--- a/src/goxel.c
+++ b/src/goxel.c
@@ -429,6 +429,9 @@ void goxel_reset(void)
         },
     };
 
+    free((void*) goxel.last_export_panel_path);
+    goxel.last_export_panel_path = NULL;
+
     if (post_reset_func != NULL) {
         post_reset_func();
         post_reset_func = NULL;

--- a/src/goxel.h
+++ b/src/goxel.h
@@ -579,6 +579,9 @@ typedef struct goxel
     } gui;
 
     char **recent_files; // stb arraw of most recently used files.
+
+    // Last save path specified in the Export panel
+    const char* last_export_panel_path;
 } goxel_t;
 
 // the global goxel instance.


### PR DESCRIPTION
This makes the "Export" panel remember the last save path, so clicking Export multiple times won't ask you to put the same path every time.
Users can click the new `Reset export path` button to select a new path.
