### PR TITLE
feat(genland): add configurable seed

### DIFF
--- a/src/filters/genland-filter.c
+++ b/src/filters/genland-filter.c
@@ -18,6 +18,8 @@
 
 #include "genland.h"
 #include "goxel.h"
+#include <time.h>
+#include <stdlib.h>
 
 /*
  * Filter that uses Tom Dobrowolski's terrain generator.
@@ -32,6 +34,7 @@ static void reset_to_default(filter_genland_t *filter) {
     filter->settings = (genland_settings_t *)malloc(sizeof(genland_settings_t));
 
     // Generation
+    filter->settings->seed = 0;
     filter->settings->max_height = 64;
     filter->settings->num_octaves = 10;
     filter->settings->amp_octave_mult = 0.4;
@@ -77,6 +80,13 @@ static int gui(filter_t *filter_)
 
     gui_input_int("Max height", &filter->settings->max_height, 0, 9999);
     gui_input_int("# Octaves", &filter->settings->num_octaves, 0, 20);
+    gui_input_int("Seed", &filter->settings->seed, 0, RAND_MAX);
+    if (gui_button("Randomize seed", -1, 0))
+    {
+        srand(time(NULL));
+        filter->settings->seed = rand();
+    }
+
     gui_input_float("Octave mult", &filter->settings->amp_octave_mult, 0.01, 0, 1, "%.2f");
     gui_input_float("River width", &filter->settings->river_width, 0.01, 0, 1, "%.2f");
     gui_input_float("Variety", &filter->settings->variety, 1.00, 0, 100, "%.0f");

--- a/src/filters/genland.cpp
+++ b/src/filters/genland.cpp
@@ -127,9 +127,11 @@ static inline float fgrad(long h, float x, float y, float z)
 }
 
 static unsigned char noisep[512], noisep15[512];
-static void noiseinit()
+static void noiseinit(int seed)
 {
     long i, j, k;
+
+    srand(seed);
 
     for (i = 256 - 1; i >= 0; i--)
         noisep[i] = i;
@@ -228,7 +230,7 @@ extern "C" void generate_tomland_terrain(volume_t *volume, genland_settings_t *s
     printf("Heightmap generator by Tom Dobrowoski (http://ged.ax.pl/~tomkh)\n");
     printf("Assistance by Ken Silverman (http://advsys.net/ken)\n");
 
-    noiseinit();
+    noiseinit(settings->seed);
 
     // Tom's algorithm from 12/04/2005
     printf("Generating landscape\n");

--- a/src/filters/genland.h
+++ b/src/filters/genland.h
@@ -10,6 +10,7 @@ typedef struct {
     // Generation
     int max_height;
     int num_octaves;
+    int seed;
     float amp_octave_mult;
     float river_width;
     float variety;


### PR DESCRIPTION
This adds a "Seed" option to genland which lets users regenerate a previous terrain with different parameters.

![image](https://github.com/user-attachments/assets/033b5942-14a3-4264-a201-0284d5484191)
