### PR TITLE
feat(genland): add option to replace layer instead of overlaying

### DIFF
--- a/src/filters/genland-filter.c
+++ b/src/filters/genland-filter.c
@@ -57,6 +57,9 @@ static void reset_to_default(filter_genland_t *filter) {
     // Lighting
     filter->settings->shadow_factor = 32;
     filter->settings->ambience_factor = 0.3;
+
+    // Transform
+    filter->settings->replace_current_layer = true;
 }
 
 static void on_open(filter_t *filter_)
@@ -104,6 +107,10 @@ static int gui(filter_t *filter_)
     gui_group_begin("Lighting");
     gui_input_float("Shadow", &filter->settings->shadow_factor, 1.00, 0, 255, "%.0f");
     gui_input_float("Ambient", &filter->settings->ambience_factor, 0.01, 0, 1, "%.2f");
+    gui_group_end();
+
+    gui_group_begin("Transform");
+    gui_checkbox("Replace layer", &filter->settings->replace_current_layer, NULL);
     gui_group_end();
 
     if (gui_button("Reset to defaults", -1, 0))

--- a/src/filters/genland.cpp
+++ b/src/filters/genland.cpp
@@ -52,6 +52,10 @@ typedef struct
 
 static void process_voxel_data(volume_t *volume, genland_settings_t *settings, vcol *argb)
 {
+    if (settings->replace_current_layer) {
+        volume_clear(volume);
+    }
+
     int pos[3];
     // Loop over each (x, y) coordinate in the buffer grid
     for (int y = 0; y < VSID; y++)

--- a/src/filters/genland.h
+++ b/src/filters/genland.h
@@ -27,6 +27,9 @@ typedef struct {
     // Lighting
     float shadow_factor;
     float ambience_factor;
+
+    // Transform
+    bool replace_current_layer;
 } genland_settings_t;
 
 EXTERNC void generate_tomland_terrain(volume_t *volume, genland_settings_t *settings);


### PR DESCRIPTION
Putting multiple classicgen generations on top of each other can be pretty cool, but most of the time you don't want this.
This PR adds an option (enabled by default) that makes genland *replace* the current layer's blocks with the newly generated ones.
