### PR TITLE
Various genland filter changes

### DIFF
--- a/src/filters/genland-filter.c
+++ b/src/filters/genland-filter.c
@@ -20,6 +20,8 @@
 #include "goxel.h"
 #include <time.h>
 #include <stdlib.h>
+#include <stdarg.h>
+#include <stdio.h>
 
 /*
  * Filter that uses Tom Dobrowolski's terrain generator.
@@ -30,42 +32,49 @@ typedef struct
     genland_settings_t *settings;
 } filter_genland_t;
 
+// Define a static instance containing all default values.
+static const genland_settings_t default_genland_settings = {
+    .seed = 0,
+    .max_height = 64,
+    .num_octaves = 10,
+    .amp_octave_mult = 0.4,
+    .river_phase = 0.75,
+    .river_width = 0.02,
+    .variety = 20.0,
+    .offset = 28.0,
+    .noise_terrain = 9.5,
+    .noise_river = 13.2,
+    .color_ground = {140, 125, 115, 255},
+    .color_grass1 = {72, 80, 32, 255},
+    .color_grass2 = {68, 78, 40, 255},
+    .color_water = {60, 100, 120, 255},
+    .shadow_factor = 32,
+    .ambience_factor = 0.3,
+    .resize_image = true,
+    .replace_current_layer = true,
+};
+
+
 static void reset_to_default(filter_genland_t *filter) {
-    filter->settings = (genland_settings_t *)malloc(sizeof(genland_settings_t));
-
-    // Generation
-    filter->settings->seed = 0;
-    filter->settings->max_height = 64;
-    filter->settings->num_octaves = 10;
-    filter->settings->amp_octave_mult = 0.4;
-    filter->settings->river_width = 0.02;
-    filter->settings->variety = 20.0;
-    filter->settings->offset = 28.0;
-    filter->settings->noise_terrain = 9.5;
-    filter->settings->noise_river = 13.2;
-
-    // Colors
-    uint8_t ground[4] = {140, 125, 115, 255};
-    uint8_t grass1[4] = {72, 80, 32, 255};
-    uint8_t grass2[4] = {68, 78, 40, 255};
-    uint8_t water[4] = {60, 100, 120, 255};
-    memcpy(filter->settings->color_ground, ground, sizeof(ground));
-    memcpy(filter->settings->color_grass1, grass1, sizeof(grass1));
-    memcpy(filter->settings->color_grass2, grass2, sizeof(grass2));
-    memcpy(filter->settings->color_water, water, sizeof(water));
-
-    // Lighting
-    filter->settings->shadow_factor = 32;
-    filter->settings->ambience_factor = 0.3;
-
-    // Transform
-    filter->settings->replace_current_layer = true;
+    if (filter->settings)
+        free(filter->settings);
+    filter->settings = malloc(sizeof(genland_settings_t));
+    if (!filter->settings)
+        return;
+    memcpy(filter->settings, &default_genland_settings, sizeof(genland_settings_t));
 }
 
-static void on_open(filter_t *filter_)
+static void gui_tooltip_with_default(const char *tooltip, const char *default_fmt, ...)
 {
-    filter_genland_t *filter = (void *)filter_;
-    reset_to_default(filter);
+    char default_str[128];
+    va_list args;
+    va_start(args, default_fmt);
+    vsnprintf(default_str, sizeof(default_str), default_fmt, args);
+    va_end(args);
+
+    char final_tooltip[256];
+    snprintf(final_tooltip, sizeof(final_tooltip), "%s. Default is '%s'", tooltip, default_str);
+    gui_tooltip_if_hovered(final_tooltip);
 }
 
 static int gui(filter_t *filter_)
@@ -73,7 +82,8 @@ static int gui(filter_t *filter_)
     filter_genland_t *filter = (void *)filter_;
     layer_t *layer = goxel.image->active_layer;
 
-    const char *help_text = "Genland by Tom Dobrowolski.";
+    const char *help_text = "Genland by Tom Dobrowolski.\n"
+        "Hover over each field to get some information about how it affects the end terrain";
     goxel_set_help_text(help_text);
 
     if (gui_collapsing_header("Hint", false))
@@ -82,8 +92,13 @@ static int gui(filter_t *filter_)
     }
 
     gui_input_int("Max height", &filter->settings->max_height, 0, 9999);
-    gui_input_int("# Octaves", &filter->settings->num_octaves, 0, 20);
+    gui_tooltip_with_default("The maximum height the generator can place blocks (and the height the image will be resized to, if enabled)", "%i", default_genland_settings.max_height);
+    
+    gui_input_int("# Octaves", &filter->settings->num_octaves, 0, 100);
+    gui_tooltip_with_default("# of times noise is applied", "%i", default_genland_settings.num_octaves);
+
     gui_input_int("Seed", &filter->settings->seed, 0, RAND_MAX);
+    gui_tooltip_with_default("'Seeding' allows for consistent generations (if using the same number)", "%i", default_genland_settings.seed);
     if (gui_button("Randomize seed", -1, 0))
     {
         srand(time(NULL));
@@ -91,7 +106,15 @@ static int gui(filter_t *filter_)
     }
 
     gui_input_float("Octave mult", &filter->settings->amp_octave_mult, 0.01, 0, 1, "%.2f");
+    gui_tooltip_with_default("How aggressively each octave of noise affects the final result, lower = less aggressive", "%.2f", default_genland_settings.amp_octave_mult);
+
     gui_input_float("River width", &filter->settings->river_width, 0.01, 0, 1, "%.2f");
+    gui_tooltip_with_default("How wide the river(s) should generate", "%.2f", default_genland_settings.river_width);
+
+    gui_input_float("River phase", &filter->settings->river_phase, 0.01, 0, 1, "%.2f");
+    gui_tooltip_with_default("Where the rivers begin, 0 = far left, 1 = far right", "%.2f", default_genland_settings.river_phase);
+
+    // TODO: Rework?/add tooltips
     gui_input_float("Variety", &filter->settings->variety, 1.00, 0, 100, "%.0f");
     gui_input_float("Offset", &filter->settings->offset, 1.00, 0, 100, "%.0f");
     gui_input_float("Terrain noise", &filter->settings->noise_terrain, 0.1, 0, 100, "%.1f");
@@ -106,11 +129,19 @@ static int gui(filter_t *filter_)
 
     gui_group_begin("Lighting");
     gui_input_float("Shadow", &filter->settings->shadow_factor, 1.00, 0, 255, "%.0f");
+    gui_tooltip_with_default("How strong shadows from a simulated sun are", "%.0f", default_genland_settings.shadow_factor);
+
     gui_input_float("Ambient", &filter->settings->ambience_factor, 0.01, 0, 1, "%.2f");
+    gui_tooltip_with_default("How strongly lighting normals affect blocks", "%.2f", default_genland_settings.ambience_factor);
     gui_group_end();
 
     gui_group_begin("Transform");
-    gui_checkbox("Replace layer", &filter->settings->replace_current_layer, NULL);
+    gui_checkbox("Replace layer", &filter->settings->replace_current_layer,
+        "If checked, this will clear the active layer before generating\n"
+        "If unchecked, we will not clear the layer before generating");
+    gui_checkbox("Resize image", &filter->settings->resize_image,
+        "If checked, we will automatically resize the image box after generating\n"
+        "If unchecked, the image box will remain as it was.");
     gui_group_end();
 
     if (gui_button("Reset to defaults", -1, 0))
@@ -122,11 +153,26 @@ static int gui(filter_t *filter_)
     {
         image_history_push(goxel.image);
         generate_tomland_terrain(layer->volume, filter->settings);
+
+        if (filter->settings->resize_image) {
+            float box[4][4];
+            volume_get_box(goxel_get_layers_volume(goxel.image), true, box);
+            int dimensions[3];
+            box_get_dimensions(box, dimensions);
+            image_set_image_dimensions_and_center(goxel.image, dimensions[0], dimensions[1], filter->settings->max_height);
+        }
     }
     return 0;
+}
+
+static void on_open(filter_t *filter_)
+{
+    filter_genland_t *filter = (void *)filter_;
+    reset_to_default(filter);
 }
 
 FILTER_REGISTER(genland, filter_genland_t,
                 .name = "Generation - Genland",
                 .on_open = on_open,
+                .panel_width = 275,
                 .gui_fn = gui, )

--- a/src/filters/genland.h
+++ b/src/filters/genland.h
@@ -13,6 +13,7 @@ typedef struct {
     int seed;
     float amp_octave_mult;
     float river_width;
+    float river_phase;
     float variety;
     float offset;
     float noise_terrain;
@@ -29,6 +30,7 @@ typedef struct {
     float ambience_factor;
 
     // Transform
+    bool resize_image;
     bool replace_current_layer;
 } genland_settings_t;
 

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -1316,6 +1316,10 @@ bool gui_checkbox(const char *label, bool *v, const char *hint)
     return ret;
 }
 
+void gui_tooltip_if_hovered(const char *info) {
+    if (info && ImGui::IsItemHovered()) gui_tooltip(info);
+}
+
 bool gui_checkbox_flag(const char *label, int *v, int flag, const char *hint)
 {
     bool ret, b;

--- a/src/gui.h
+++ b/src/gui.h
@@ -107,6 +107,7 @@ typedef struct gui_icon_info
 bool gui_icons_grid(int nb, const gui_icon_info_t *icons, int *current);
 
 bool gui_tab(const char *label, int icon, bool *v);
+void gui_tooltip_if_hovered(const char *info);
 bool gui_checkbox(const char *label, bool *v, const char *hint);
 bool gui_checkbox_flag(const char *label, int *v, int flag, const char *hint);
 bool gui_input_int(const char *label, int *v, int minv, int maxv);

--- a/src/gui/menu.c
+++ b/src/gui/menu.c
@@ -39,10 +39,10 @@ static void import_image_plane(void)
 static void import_hmap_cmap(void) {
     const char *hmap_path;
     const char *cmap_path;
-    const char *filters[] = {"*.png", "*.bmp", "*.jpg", "*.jpeg", NULL};
-    hmap_path = sys_open_file_dialog("Choose heightmap image", NULL, filters, "png, jpeg, bmp");
+    const char *filters[] = {"*.bmp", NULL};
+    hmap_path = sys_open_file_dialog("Choose heightmap image", NULL, filters, "bmp");
     if (!hmap_path) return;
-    cmap_path = sys_open_file_dialog("Choose colormap image", NULL, filters, "png, jpeg, bmp");
+    cmap_path = sys_open_file_dialog("Choose colormap image", NULL, filters, "bmp");
     if (!cmap_path) return;
     LOG_I("Importing\nhmap: '%s'\ncmap: '%s'\n", hmap_path, cmap_path);
     goxel_import_hmap_cmap(hmap_path, cmap_path);

--- a/src/image.h
+++ b/src/image.h
@@ -89,6 +89,8 @@ bool material_name_exists(void *user, const char *name);
 bool layer_name_exists(void *user, const char *name);
 bool camera_name_exists(void *user, const char *name);
 
+void image_set_image_dimensions_and_center(image_t *img, int w, int h, int d);
+
 /*
  * Function: image_get_key
  * Return a value that is guarantied to change when the image change.

--- a/src/volume_utils.c
+++ b/src/volume_utils.c
@@ -519,6 +519,18 @@ void box_get_start_pos(float box[4][4], int start_pos[3]) {
     start_pos[2] = box[3][2] - box[2][2];   // z starting position
 }
 
+void volume_get_dimensions(const volume_t *volume, int dimensions[3]) {
+    float box[4][4];
+    volume_get_box(volume, true, box);
+    box_get_dimensions(box, dimensions);
+}
+
+void volume_get_start_pos(const volume_t *volume, int start_pos[3]) {
+    float box[4][4];
+    volume_get_box(volume, true, box);
+    box_get_start_pos(box, start_pos);
+}
+
 void allocate_heights(int dimensions[3], int **heights) {
     *heights = (int *)malloc(dimensions[0] * dimensions[1] * sizeof(int));
 

--- a/src/volume_utils.h
+++ b/src/volume_utils.h
@@ -131,8 +131,18 @@ typedef struct painter {
 
 
 /* Function: volume_get_box
- * Compute the bounding box of a mesh.  */
+ * Compute the bounding box of a volume.  */
 void volume_get_box(const volume_t *volume, bool exact, float box[4][4]);
+/*
+ * Function: volume_get_dimensions
+ * Given a volume, grab the x/y/z (width/depth/height) dimensions.
+ */
+void volume_get_dimensions(const volume_t *volume, int dimensions[3]);
+/*
+ * Function: volume_get_start_pos
+ * Given a volume, grab the x/y/z of the starting point.
+ */
+void volume_get_start_pos(const volume_t *volume, int start_pos[3]);
 
 /*
  * Function: box_get_dimensions


### PR DESCRIPTION
- Restrict hmap + cmap to just bmp for now
- Introduce static default settings for future reference
- Add tooltips to genland fields
- Add river_phase (to set river position offset)
- Don't add rivers at all if river width is 0
- Add start_pos to generation so it isn't generating from middle of image box anymore
- Add resize_image to auto resize image after generation