### PR TITLE
Various changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           msystem: MINGW64
           update: true
-          install: mingw-w64-x86_64-gcc mingw-w64-x86_64-glfw mingw-w64-x86_64-libtre-git mingw-w64-x86_64-libpng scons make git
+          install: mingw-w64-x86_64-gcc mingw-w64-x86_64-glfw libtre-git mingw-w64-x86_64-libpng scons make git
 
       - name: Build Goxel
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           msystem: MINGW64
           update: true
-          install: mingw-w64-x86_64-gcc mingw-w64-x86_64-glfw libtre-git mingw-w64-x86_64-libpng scons make git
+          install: mingw-w64-x86_64-gcc mingw-w64-x86_64-glfw libtre-git mingw-w64-x86_64-libpng mingw-w64-x86_64-glew scons make git
 
       - name: Build Goxel
         run: |

--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ You need to install msys2 mingw, and the following packages:
     pacman -S mingw-w64-x86_64-gcc
     pacman -S mingw-w64-x86_64-glfw
     pacman -S mingw-w64-x86_64-libtre-git
+    pacman -S mingw-w64-x86_64-glew
+    pacman -S mingw-w64-x86_64-libpng
     pacman -S scons
     pacman -S make
 

--- a/SConstruct
+++ b/SConstruct
@@ -66,7 +66,7 @@ if env['werror']:
     env.Append(CCFLAGS='-Werror')
 
 if env['mode'] not in ['debug', 'analyze']:
-    env.Append(CPPDEFINES='NDEBUG', CCFLAGS='-Ofast')
+    env.Append(CPPDEFINES='NDEBUG', CCFLAGS='-O3 -ffast-math')
 
 if env['mode'] == 'debug':
     env.Append(CCFLAGS=['-O0'])

--- a/SConstruct
+++ b/SConstruct
@@ -95,7 +95,7 @@ if target_os == 'posix':
     env.ParseConfig('pkg-config --libs glfw3')
 
 # Windows compilation support.
-if target_os == 'msys' or target_os == 'cygwin':
+if target_os == 'msys':
     env.Append(CXXFLAGS=['-Wno-attributes', '-Wno-unused-variable',
                          '-Wno-unused-function'])
     env.Append(CCFLAGS=['-Wno-error=address']) # To remove if possible.

--- a/SConstruct
+++ b/SConstruct
@@ -95,7 +95,7 @@ if target_os == 'posix':
     env.ParseConfig('pkg-config --libs glfw3')
 
 # Windows compilation support.
-if target_os == 'msys':
+if target_os == 'msys' or target_os == 'cygwin':
     env.Append(CXXFLAGS=['-Wno-attributes', '-Wno-unused-variable',
                          '-Wno-unused-function'])
     env.Append(CCFLAGS=['-Wno-error=address']) # To remove if possible.

--- a/src/camera.c
+++ b/src/camera.c
@@ -198,6 +198,32 @@ void camera_turntable(camera_t *camera, float rz, float rx)
     mat4_itranslate(camera->mat, 0, 0, camera->dist);
 }
 
+void camera_turntable_around_point(
+        camera_t *camera, float rz, float rx, const float pivot[3])
+{
+    float mat[4][4] = MAT4_IDENTITY;
+    float camera_to_pivot[3];
+
+    // Calculate vector from camera to pivot point
+    vec3_sub(pivot, camera->mat[3], camera_to_pivot);
+    float new_dist = vec3_norm(camera_to_pivot);
+
+    // Apply horizontal rotation around the pivot point
+    mat4_itranslate(mat, pivot[0], pivot[1], pivot[2]);
+    mat4_irotate(mat, rz, 0, 0, 1);
+    mat4_itranslate(mat, -pivot[0], -pivot[1], -pivot[2]);
+    mat4_imul(mat, camera->mat);
+    mat4_copy(mat, camera->mat);
+
+    // Apply vertical rotation around the pivot point
+    mat4_itranslate(camera->mat, 0, 0, -new_dist);
+    mat4_irotate(camera->mat, rx, 1, 0, 0);
+    mat4_itranslate(camera->mat, 0, 0, new_dist);
+
+    // Update camera distance to match the new distance to pivot
+    camera->dist = new_dist;
+}
+
 /* First person move
  * rz: up is +ve, down is -ve.
  * ry: forward is +ve, backwards is -ve.

--- a/src/camera.h
+++ b/src/camera.h
@@ -130,6 +130,8 @@ uint32_t camera_get_key(const camera_t *camera);
 
 void camera_turntable(camera_t *camera, float rz, float rx);
 
+void camera_turntable_around_point(camera_t *camera, float rz, float rx, const float pivot[3]);
+
 /* 
  * First person strafing/camera motion.
  * rz: up is +ve, down is -ve.

--- a/src/file_format.c
+++ b/src/file_format.c
@@ -26,6 +26,7 @@
 // The global hash table of file formats.
 file_format_t *file_formats = NULL;
 file_format_t *file_formats_import_to_volume = NULL;
+file_format_t *file_formats_export_to_volume = NULL;
 
 static bool endswith(const char *str, const char *end)
 {
@@ -42,6 +43,9 @@ void file_format_register(file_format_t *format)
     if (format->import_volume_func) {
         DL_APPEND(file_formats_import_to_volume, format);
     }
+    if (format->export_volume_func) {
+        DL_APPEND(file_formats_export_to_volume, format);
+    }
 }
 
 const file_format_t *file_format_for_path(const char *path, const char *name,
@@ -50,6 +54,7 @@ const file_format_t *file_format_for_path(const char *path, const char *name,
     const file_format_t *f;
     bool need_read = strchr(mode, 'r');
     bool need_read_volume = strchr(mode, 'v');
+    bool need_write_volume = strchr(mode, 't');
     bool need_write = strchr(mode, 'w');
     const char *ext;
 
@@ -60,6 +65,7 @@ const file_format_t *file_format_for_path(const char *path, const char *name,
         if (need_read && !f->import_func) continue;
         if (need_write && !f->export_func) continue;
         if (need_read_volume && !f->import_volume_func) continue;
+        if (need_write_volume && !f->export_volume_func) continue;
         if (name && strcasecmp(f->name, name) != 0) continue;
         if (path) {
             ext = f->exts[0] + 1; // Pick the string after '*'.
@@ -88,10 +94,12 @@ void file_format_iter(const char *mode, void *user,
     bool need_read = strchr(mode, 'r');
     bool need_read_volume = strchr(mode, 'v');
     bool need_write = strchr(mode, 'w');
+    bool need_write_volume = strchr(mode, 't');
     DL_FOREACH(file_formats, f) {
         if (need_read && !f->import_func) continue;
         if (need_write && !f->export_func) continue;
         if (need_read_volume && !f->import_volume_func) continue;
+        if (need_write_volume && !f->export_volume_func) continue;
         fun(user, f);
     }
 }

--- a/src/file_format.h
+++ b/src/file_format.h
@@ -31,6 +31,8 @@ struct file_format
     void            (*export_gui)(file_format_t *format);
     int             (*export_func)(const file_format_t *format,
                                    const image_t *img, const char *path);
+    int             (*export_volume_func)(const file_format_t *format, const volume_t *volume,
+                                   const char *path);
     int             (*import_func)(const file_format_t *format, image_t *img,
                                    const char *path);
     void            (*import_gui)(file_format_t *format);
@@ -53,6 +55,7 @@ const file_format_t *file_format_by_name(const char *name);
 // The global list of registered file formats.
 extern file_format_t *file_formats;
 extern file_format_t *file_formats_import_to_volume;
+extern file_format_t *file_formats_export_to_volume;
 
 #define FILE_FORMAT_REGISTER(id_, ...) \
     static file_format_t GOX_format_##id_ = {__VA_ARGS__}; \

--- a/src/filters/coords.c
+++ b/src/filters/coords.c
@@ -28,11 +28,33 @@ typedef struct
 
 static int gui(filter_t *filter_)
 {
-    if (gui_button("Log to console", 0, 0)) {
-        LOG_I("(%.0f, %.0f, %.0f)", goxel.selection[3][0]-0.5, goxel.selection[3][1]-0.5, goxel.selection[3][2]-0.5);
-    }
-    if (gui_button("---------", 0, 0)) {
-        LOG_I("------------");
+    gui_text("This tool uses your current\nselection to print coordinates\nout to the console for later use.");
+    gui_separator();
+    if (box_is_null(goxel.selection)) {
+        if (goxel.tool->id != TOOL_SELECTION) {
+            if (gui_button("Switch to selection tool", 0, 0)) {
+                action_exec(action_get(ACTION_tool_set_selection, true));
+            }
+        } else {
+            gui_text("\nPlease create a 1x1x1 selection");
+        }
+    } else {
+        if (gui_button("Log to console", 0, 0)) {
+            float sx = goxel.selection[3][0] - 0.5f;
+            float sy = goxel.selection[3][1] - 0.5f;
+            float sz = goxel.selection[3][2] - 0.5f;
+
+            float ox = round(goxel.image->box[3][0] - goxel.image->box[0][0]);   // box origin x
+            float oy = round(goxel.image->box[3][1] - goxel.image->box[1][1]);   // box origin y
+            float oz = round(goxel.image->box[3][2] - goxel.image->box[2][2]);   // box origin z
+
+            //LOG_I("(%.0f, %.0f, %.0f)", goxel.selection[3][0]-0.5, goxel.selection[3][1]-0.5, goxel.selection[3][2]-0.5);
+            LOG_I("(%.0f, %.0f, %.0f)", sx - ox, sy - oy, sz - oz);
+        }
+        if (gui_button("Add separator", 0, 0)) {
+            LOG_I("------------");
+        }
+        gui_action_button(ACTION_reset_selection, "Reset selection", 1.0);
     }
     
     return 0;

--- a/src/filters/coords.c
+++ b/src/filters/coords.c
@@ -1,0 +1,43 @@
+/* Goxel 3D voxels editor
+ *
+ * copyright (c) 2024-present Guillaume Chereau <guillaume@noctua-software.com>
+ *
+ * Goxel is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+
+ * Goxel is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+
+ * You should have received a copy of the GNU General Public License along with
+ * goxel.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "goxel.h"
+
+/*
+ * Log the current position of the selection box.
+ */
+typedef struct
+{
+    filter_t filter;
+} filter_coords_t;
+
+static int gui(filter_t *filter_)
+{
+    if (gui_button("Log to console", 0, 0)) {
+        LOG_I("(%.0f, %.0f, %.0f)", goxel.selection[3][0]-0.5, goxel.selection[3][1]-0.5, goxel.selection[3][2]-0.5);
+    }
+    if (gui_button("---------", 0, 0)) {
+        LOG_I("------------");
+    }
+    
+    return 0;
+}
+
+FILTER_REGISTER(coords, filter_coords_t,
+                .name = "Log - Coordinates",
+                .gui_fn = gui, )

--- a/src/filters/doodad-placement.c
+++ b/src/filters/doodad-placement.c
@@ -458,12 +458,12 @@ static int gui(filter_t *filter_)
         gui_tooltip_if_hovered("Offset doodads vertically by an amount");
     }
 
-    if (gui_collapsing_header("Reference heights", false)) {
+    if (gui_collapsing_header("Reference heights", true)) {
         gui_checkbox(
             "Use entire image",
             &filter->use_image_heights,
-            "If checked, all visible layers will be used to work out potential heights to place doodads at.\n"
-            "If unchecked, only a specific/chosen layer will inform the placement heights.");
+            "If checked, blocks in all visible layers will be considered for potential placements.\n"
+            "If unchecked, a specific layer will be considered and the rest are ignored.");
         if (!filter->use_image_heights) {
             if (!filter->height_layer)
                 filter->height_layer = goxel.image->layers; // First one.
@@ -491,22 +491,22 @@ static int gui(filter_t *filter_)
         }
     }
 
-    if(gui_collapsing_header("Restrictions", true)) {
-        gui_checkbox(
-            "Place on lowest",
-            &filter->place_on_0,
-            "If checked, the placement won't ignore the bottom layer of the map.\n"
-            "If unchecked, the placement will ignore the bottom layer of the map as a potential placement spot.");
+    if(gui_collapsing_header("Flags", true)) {
         gui_checkbox(
             "Place on empty",
             &filter->place_on_empty,
             "If checked, the placement will allow placing where there are no blocks.\n"
             "If unchecked, the placement will require there to be blocks.");
         gui_checkbox(
+            "Place on lowest",
+            &filter->place_on_0,
+            "If checked, the placement will be allowed to be on the first/bottom layer of the map.\n"
+            "If unchecked, the placement will ignore the first/bottom layer of the map as a potential placement spot.");
+        gui_checkbox(
             "Ignore height restrictions",
             &filter->ignore_height_restrictions,
             "If checked, the placement will not do height checks - it may place out of bounds vertically.\n"
-            "If unchecked, the placement will not place the doodad if it goes outside of the box vertically.");
+            "If unchecked, the placement will not place the doodad if it would extend out of the box vertically.");
     }
 
     if (gui_collapsing_header("Variation", true)) {
@@ -528,7 +528,7 @@ static int gui(filter_t *filter_)
         gui_checkbox(
             "Randomly flip",
             &filter->randomly_flip,
-            "If checked, sometimes it'll flip.\n"
+            "If checked, sometimes it'll flip the doodad.\n"
             "If unchecked, it won't flip.");
     }
 

--- a/src/filters/genland.cpp
+++ b/src/filters/genland.cpp
@@ -48,7 +48,7 @@ typedef struct
 
 // Anything less than 512/9 seems to crash
 #define VSID 512
-#define VSHL 9
+#define VSHL 9 // used in lighting calc
 
 static void process_voxel_data(volume_t *volume, genland_settings_t *settings, vcol *argb)
 {

--- a/src/filters/shadows-simple.c
+++ b/src/filters/shadows-simple.c
@@ -1,0 +1,227 @@
+/* Goxel 3D voxels editor
+ *
+ * copyright (c) 2024-present Guillaume Chereau <guillaume@noctua-software.com>
+ *
+ * Goxel is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+
+ * Goxel is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+
+ * You should have received a copy of the GNU General Public License along with
+ * goxel.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "goxel.h"
+#include "volume.h"
+#include <math.h>
+#include <stdbool.h>
+#include <time.h>
+
+/*
+ * Filter to apply baked shadows.
+ */
+typedef struct
+{
+    filter_t filter;
+    float strength;
+    float multi_block_multiplier;
+    bool do_smoothing;
+} filter_simple_shadows_t;
+
+void adjust_colour_brightness(uint8_t colour[4], float multiplier)
+{
+    for (int i = 0; i < 3; i++)
+    { // Only R, G, B
+        int c = (int)(colour[i] * multiplier);
+        if (c < 0)
+            c = 0;
+        if (c > 255)
+            c = 255;
+        colour[i] = (uint8_t)c;
+    }
+}
+
+int ind(int x, int y, int width, int height)
+{
+    int wrapped_x = (x + width) % width;
+    int wrapped_y = (y + height) % height;
+    return wrapped_y * width + wrapped_x;
+}
+
+static int gui(filter_t *filter_)
+{
+    filter_simple_shadows_t *filter = (void *)filter_;
+
+    const char *help_text = "This filter applies shadow to the current layer, using blocks from other visible layers, directly vertically downwards.";
+    goxel_set_help_text(help_text);
+
+    if (gui_collapsing_header("Hint", false))
+    {
+        gui_text_wrapped(help_text);
+    }
+
+    gui_group_begin(NULL);
+    gui_input_float("Strength", &filter->strength, 0.01, 0, 1, "%.2f");
+    gui_input_float("Multi-block multiplier", &filter->multi_block_multiplier, 0.01, 0, 1, "%.2f");
+
+    gui_tooltip_if_hovered("This makes columns with more blocks apply a darker shadow beneath it.\n"
+                           "If this is 1, if there's 10 blocks above, only 'Strength' darkening is applied.\n"
+                           "With multi-block multiplier, each additional block between the active layer's top block and the top of the map multiplies by this.");
+
+    gui_checkbox("Apply smoothing", &filter->do_smoothing, "If checked, apply 2x2 smoothing\n"
+                                                           "If unchecked, do no smoothing");
+    gui_group_end();
+
+    if (gui_button("Apply", -1, 0))
+    {
+        image_history_push(goxel.image);
+        layer_t *layer = goxel.image->active_layer;
+
+        layer->visible = false;
+        const volume_t *other_visible_layers_combined = goxel_get_layers_volume(goxel.image);
+        layer->visible = true;
+
+        int dims[3], start_pos[3], pos[3];
+        float box[4][4];
+        // layer_get_bounding_box(layer, box);
+        mat4_copy(goxel.image->box, box);
+        box_get_dimensions(box, dims);
+        box_get_start_pos(box, start_pos);
+
+        volume_iterator_t iter;
+        iter = volume_get_iterator(other_visible_layers_combined, VOLUME_ITER_VOXELS | VOLUME_ITER_SKIP_EMPTY);
+
+        float *shadow_map;
+        shadow_map = malloc(sizeof(float) * dims[0] * dims[1]);
+
+        int *heights;
+        allocate_heights(dims, &heights);
+        volume_get_heights(layer->volume, heights);
+        printf("Simple shadow setup complete\n");
+
+        // Formulate the shadow map
+        int num_blocks_above_current, height;
+        uint8_t col[4];
+        int globalIndex = 0;
+        int x, y, z;
+
+        for (y = 0; y < dims[1]; y++)
+        {
+            pos[1] = y + start_pos[1];
+
+            for (x = 0; x < dims[0]; x++, globalIndex++)
+            {
+                pos[0] = x + start_pos[0];
+                num_blocks_above_current = 0;
+
+                // Loop from top of map (max Z) down to the height of the current layer
+                height = heights[globalIndex];
+                for (z = dims[2]; z > height; z--)
+                {
+                    pos[2] = z + start_pos[2];
+                    volume_get_at(other_visible_layers_combined, &iter, pos, col);
+                    if (col[3] != 0)
+                    {
+                        num_blocks_above_current++;
+                    }
+                }
+
+                // printf("%u/%u: %u active height, %u blocks found\n", x, y, height, num_blocks_above_current);
+                shadow_map[globalIndex] = num_blocks_above_current;
+            }
+        }
+        printf("Shadow map formulated\n");
+
+        // Now we pivot from the shadow_map containing the # of blocks found, to the color multiplier
+        // If no blocks, we want a multiplier of 1, if there are blocks, we want to use 'strength' to multiply down
+        int num_blocks = 0;
+        float mult;
+        globalIndex = 0;
+        for (y = 0; y < dims[1]; y++)
+        {
+            for (x = 0; x < dims[0]; x++, globalIndex++)
+            {
+                // If there's no shadow, return 1
+                if (shadow_map[globalIndex] == 0)
+                {
+                    shadow_map[globalIndex] = 1;
+                    // printf("No blocks above found, skipping\n");
+                    continue;
+                }
+                // There are blocks, start at strength and mult down
+                mult = filter->strength;
+                if (filter->multi_block_multiplier != 1)
+                {
+                    for (num_blocks = shadow_map[globalIndex]; num_blocks >= 0; num_blocks--)
+                    {
+                        mult *= filter->multi_block_multiplier;
+                    }
+                }
+                // printf("Applying mult: %f\n", mult);
+                shadow_map[globalIndex] = mult;
+            }
+        }
+        printf("Shadow multiplier set\n");
+
+        float amt = 0;
+        if (filter->do_smoothing)
+        {
+            for (y = 0; y < dims[1]; y++)
+            {
+                for (x = 0; x < dims[0]; x++)
+                {
+                    // Apply smoothing (if applicable)
+                    globalIndex = ind(x, y, dims[0], dims[1]);
+                    amt = (shadow_map[globalIndex] +
+                        shadow_map[ind(x, y + 1, dims[0], dims[1])] +
+                        shadow_map[ind(x + 1, y, dims[0], dims[1])] +
+                        shadow_map[ind(x + 1, y + 1, dims[0], dims[1])]) /
+                       4;
+                    shadow_map[globalIndex] = amt;
+                }
+            }
+            printf("Smoothing completed\n");
+        }
+
+        // Apply the shadows to the volume
+        iter = volume_get_iterator(layer->volume, VOLUME_ITER_VOXELS | VOLUME_ITER_SKIP_EMPTY);
+        globalIndex = 0;
+        for (y = 0; y < dims[1]; y++)
+        {
+            pos[1] = y + start_pos[1];
+            for (x = 0; x < dims[0]; x++, globalIndex++)
+            {
+                pos[0] = x + start_pos[0];
+                pos[2] = heights[globalIndex];
+                // printf("Pos: %i/%i/%i\n", pos[0], pos[1], pos[2]);
+                volume_get_at(layer->volume, &iter, pos, col);
+                // printf("Color at: %u/%u/%u\n", (unsigned int)col[0], (unsigned int)col[1], (unsigned int)col[2]);
+                adjust_colour_brightness(col, shadow_map[globalIndex]);
+                volume_set_at(layer->volume, &iter, pos, col);
+            }
+        }
+
+        printf("Shadows finished\n");
+        free(shadow_map);
+        free(heights);
+    }
+    return 0;
+}
+
+static void on_open(filter_t *filter_)
+{
+    filter_simple_shadows_t *filter = (void *)filter_;
+    filter->multi_block_multiplier = 1;
+    filter->strength = 0.6;
+    filter->do_smoothing = true;
+}
+
+FILTER_REGISTER(simple_shadows, filter_simple_shadows_t,
+                .name = "Generate - Shadows (Simple)",
+                .on_open = on_open,
+                .gui_fn = gui, )

--- a/src/filters/shadows-simple.c
+++ b/src/filters/shadows-simple.c
@@ -30,6 +30,7 @@ typedef struct
     filter_t filter;
     float strength;
     float multi_block_multiplier;
+    float multi_block_cap;
     bool do_smoothing;
 } filter_simple_shadows_t;
 
@@ -67,7 +68,8 @@ static int gui(filter_t *filter_)
 
     gui_group_begin(NULL);
     gui_input_float("Strength", &filter->strength, 0.01, 0, 1, "%.2f");
-    gui_input_float("Multi-block multiplier", &filter->multi_block_multiplier, 0.01, 0, 1, "%.2f");
+    gui_input_float("Multi-block multiplier\n(per block)", &filter->multi_block_multiplier, 0.01, 0, 1, "%.2f");
+    gui_input_float("Multi-block multiplier limit", &filter->multi_block_cap, 0.01, 0, 1, "%.2f");
 
     gui_tooltip_if_hovered("This makes columns with more blocks apply a darker shadow beneath it.\n"
                            "If this is 1, if there's 10 blocks above, only 'Strength' darkening is applied.\n"
@@ -160,6 +162,10 @@ static int gui(filter_t *filter_)
                     for (num_blocks = shadow_map[globalIndex]; num_blocks >= 0; num_blocks--)
                     {
                         mult *= filter->multi_block_multiplier;
+                        if (mult < filter->multi_block_cap) {
+                            mult = filter->multi_block_cap;
+                            break;
+                        }
                     }
                 }
                 // printf("Applying mult: %f\n", mult);
@@ -216,12 +222,14 @@ static int gui(filter_t *filter_)
 static void on_open(filter_t *filter_)
 {
     filter_simple_shadows_t *filter = (void *)filter_;
-    filter->multi_block_multiplier = 1;
-    filter->strength = 0.6;
+    filter->multi_block_multiplier = 0.9;
+    filter->multi_block_cap = 0.5;
+    filter->strength = 0.9;
     filter->do_smoothing = true;
 }
 
 FILTER_REGISTER(simple_shadows, filter_simple_shadows_t,
                 .name = "Generate - Shadows (Simple)",
                 .on_open = on_open,
-                .gui_fn = gui, )
+                .gui_fn = gui, 
+                .panel_width = 300, )

--- a/src/filters/shadows-simple.c
+++ b/src/filters/shadows-simple.c
@@ -67,8 +67,9 @@ static int gui(filter_t *filter_)
     }
 
     gui_group_begin(NULL);
+    gui_label_size_push(220.0f);
     gui_input_float("Strength", &filter->strength, 0.01, 0, 1, "%.2f");
-    gui_input_float("Multi-block multiplier\n(per block)", &filter->multi_block_multiplier, 0.01, 0, 1, "%.2f");
+    gui_input_float("Multi-block multiplier (per block)", &filter->multi_block_multiplier, 0.01, 0, 1, "%.2f");
     gui_input_float("Multi-block multiplier limit", &filter->multi_block_cap, 0.01, 0, 1, "%.2f");
 
     gui_tooltip_if_hovered("This makes columns with more blocks apply a darker shadow beneath it.\n"
@@ -77,6 +78,7 @@ static int gui(filter_t *filter_)
 
     gui_checkbox("Apply smoothing", &filter->do_smoothing, "If checked, apply 2x2 smoothing\n"
                                                            "If unchecked, do no smoothing");
+    gui_label_size_pop();
     gui_group_end();
 
     if (gui_button("Apply", -1, 0))
@@ -232,4 +234,4 @@ FILTER_REGISTER(simple_shadows, filter_simple_shadows_t,
                 .name = "Generate - Shadows (Simple)",
                 .on_open = on_open,
                 .gui_fn = gui, 
-                .panel_width = 300, )
+                .panel_width = 450, )

--- a/src/filters/squash.c
+++ b/src/filters/squash.c
@@ -35,7 +35,7 @@ static int gui(filter_t *filter_)
     int x, y, z, pos[3], new_pos[3], dimensions[3], start_pos[3];
     uint8_t cur_block_color[4];
 
-    const char *help_text = "This filter condenses layer vertically by a %";
+    const char *help_text = "This filter condenses the current layer vertically by a percentage.";
     goxel_set_help_text(help_text);
 
     if(gui_collapsing_header("Hint", false)) {

--- a/src/formats/txt.c
+++ b/src/formats/txt.c
@@ -70,11 +70,9 @@ static int import_as_txt(const file_format_t *format, image_t *image,
     return import_as_txt_to_volume(format, layer->volume, path);
 }
 
-static int export_as_txt(const file_format_t *format, const image_t *image,
-                         const char *path)
+static int export_volume_as_txt(const file_format_t *format, const volume_t *volume, const char *path)
 {
     FILE *out;
-    const volume_t *volume = goxel_get_layers_volume(image);
     int p[3];
     uint8_t v[4];
     volume_iterator_t iter;
@@ -99,6 +97,12 @@ static int export_as_txt(const file_format_t *format, const image_t *image,
     return 0;
 }
 
+static int export_as_txt(const file_format_t *format, const image_t *image,
+                         const char *path)
+{
+    return export_volume_as_txt(format, goxel_get_layers_volume(image), path);
+}
+
 FILE_FORMAT_REGISTER(txt,
     .name = "text",
     .exts = {"*.txt"},
@@ -106,4 +110,5 @@ FILE_FORMAT_REGISTER(txt,
     .import_func = import_as_txt,
     .import_volume_func = import_as_txt_to_volume,
     .export_func = export_as_txt,
+    .export_volume_func = export_volume_as_txt,
 )

--- a/src/goxel.c
+++ b/src/goxel.c
@@ -392,7 +392,7 @@ void goxel_reset(void)
         .smoothness = 0,
         .noise_enabled = 0,
         .noise_coverage = 100,
-        .noise_intensity = 20,
+        .noise_intensity = 5,
         .noise_saturation = 5,
         .color = {255, 255, 255, 255},
     };

--- a/src/goxel.c
+++ b/src/goxel.c
@@ -1519,6 +1519,7 @@ ACTION_REGISTER(ACTION_reset_selection,
 static void a_fill_selection(void)
 {
     layer_t *layer = goxel.image->active_layer;
+    image_history_push(goxel.image);
 
     if (!volume_is_empty(goxel.mask)) {
         volume_merge(layer->volume, goxel.mask, MODE_OVER, goxel.painter.color);

--- a/src/goxel.c
+++ b/src/goxel.c
@@ -641,6 +641,42 @@ static int on_rotate(const gesture_t *gest, void *user)
     if (gest->state == GESTURE_BEGIN) {
         mat4_copy(camera->mat, goxel.move_origin.camera_mat);
         vec2_copy(gest->pos, goxel.move_origin.pos);
+        
+        // Try to detect a voxel under the mouse cursor for distance-based rotation
+        float voxel_pos[3], voxel_normal[3];
+        bool found_voxel = goxel_unproject_on_volume(
+            gest->viewport, gest->pos, goxel_get_layers_volume(goxel.image), 
+            voxel_pos, voxel_normal);
+
+        if (found_voxel) {
+            // Found a voxel - calculate pivot point at center of view at same distance
+            float camera_pos[3], camera_to_voxel[3];
+            float viewport_center[2];
+            float ray_origin[3], ray_dir[3];
+
+            // Get camera position
+            vec3_copy(camera->mat[3], camera_pos);
+
+            // Calculate distance from camera to voxel
+            vec3_sub(voxel_pos, camera_pos, camera_to_voxel);
+            float distance = vec3_norm(camera_to_voxel);
+
+            // Get viewport center coordinates
+            viewport_center[0] = gest->viewport[0] + gest->viewport[2] / 2.0f;
+            viewport_center[1] = gest->viewport[1] + gest->viewport[3] / 2.0f;
+
+            // Get ray from center of viewport
+            camera_get_ray(camera, viewport_center, gest->viewport, ray_origin, ray_dir);
+
+            // Calculate pivot point at the same distance along the center ray
+            vec3_mul(ray_dir, distance, ray_dir);
+            vec3_add(ray_origin, ray_dir, goxel.move_origin.pivot_point);
+
+            goxel.move_origin.has_pivot_point = true;
+        } else {
+            // No voxel found - use default rotation
+            goxel.move_origin.has_pivot_point = false;
+        }
     }
 
     x1 = goxel.move_origin.pos[0] / gest->viewport[2];
@@ -651,7 +687,13 @@ static int on_rotate(const gesture_t *gest, void *user)
     x_rot = (y2 - y1) * 2 * M_PI;
 
     mat4_copy(goxel.move_origin.camera_mat, camera->mat);
-    camera_turntable(camera, z_rot, x_rot);
+        
+    // Use pivot-based rotation if we have a voxel under the cursor
+    if (goxel.move_origin.has_pivot_point) {
+        camera_turntable_around_point(camera, z_rot, x_rot, goxel.move_origin.pivot_point);
+    } else {
+        camera_turntable(camera, z_rot, x_rot);
+    }
     return 0;
 }
 

--- a/src/goxel.h
+++ b/src/goxel.h
@@ -74,7 +74,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define GOXEL_VERSION_STR "0.13.0-aos-0_2l"
+#define GOXEL_VERSION_STR "0.13.0-aos-0_2m"
 #ifndef GOXEL_DEFAULT_THEME
 #   define GOXEL_DEFAULT_THEME "dark"
 #endif

--- a/src/goxel.h
+++ b/src/goxel.h
@@ -596,7 +596,6 @@ extern goxel_t goxel;
 void goxel_init(void);
 void goxel_release(void);
 void goxel_reset(void);
-void goxel_reset_512(void);
 
 // Probably better to merge those two.
 int goxel_iter(const inputs_t *inputs);

--- a/src/goxel.h
+++ b/src/goxel.h
@@ -547,6 +547,9 @@ typedef struct goxel
         float  pos[2];
         float  camera_ofs[3];
         float  camera_mat[4][4];
+        // Pivot point for rotation around hovered voxel
+        float  pivot_point[3];
+        bool   has_pivot_point;
     } move_origin;
 
     palette_t  *palettes;   // The list of all the palettes

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -73,8 +73,11 @@ bool gui_pan_scroll_behavior(int dir);
 #pragma GCC diagnostic pop
 #endif
 
-// How much space we keep for the labels on the left.
-static const float LABEL_SIZE = 90;
+// How much space we keep for the labels on the left
+// Use gui_label_size_get to acquire, gui_label_size_push(value) to temp change from the default, and remember to gui_label_size_pop() afterwards
+static float g_label_size_stack[16];
+static int   g_label_size_top = 0;
+static float g_label_size_default = 90.0f;
 
 // Base height of items (note: maybe remove and use the font size instead?).
 static const float ITEM_HEIGHT = 18;
@@ -409,6 +412,9 @@ static void gui_init(void)
 
     ImGuiIO& io = ImGui::GetIO();
     if (!io.Fonts->TexID) load_fonts_texture();
+
+    g_label_size_stack[0] = g_label_size_default;
+    g_label_size_top = 1;
 }
 
 void gui_release(void)
@@ -816,6 +822,29 @@ gui_window_ret_t gui_window_end(void)
     return ret;
 }
 
+void gui_label_size_push(float v)
+{
+    if (g_label_size_top >= (int)(sizeof(g_label_size_stack) / sizeof(g_label_size_stack[0]))) {
+        LOG_E("gui_label_size_push: label size stack overflow");
+        return;
+    }
+    g_label_size_stack[g_label_size_top++] = v;
+}
+
+void gui_label_size_pop(void)
+{
+    if (g_label_size_top <= 1) {
+        LOG_E("gui_label_size_pop: attempted to pop base label size");
+        return;
+    }
+    if (g_label_size_top > 1)
+        g_label_size_top--;
+}
+float gui_label_size_get(void)
+{
+    return g_label_size_stack[g_label_size_top - 1];
+}
+
 bool gui_input_int(const char *label, int *v, int minv, int maxv)
 {
     float minvf = minv;
@@ -864,7 +893,7 @@ bool slider_float(const char *label, float *v, float minv, float maxv, const cha
 
     ImGui::PushID(label);
     ImGui::BeginGroup();
-    label_aligned(label, LABEL_SIZE);
+    label_aligned(label, gui_label_size_get());
     // Render an imgui DragFloat with transparent background.
     draw_list->ChannelsSplit(2);
     draw_list->ChannelsSetCurrent(1);
@@ -935,7 +964,7 @@ bool gui_input_float(const char *label, float *v, float step,
     ImGui::PushStyleColor(ImGuiCol_SliderGrab,
                     COLOR(NUMBER_INPUT, ITEM, false));
 
-    label_aligned(label, LABEL_SIZE);
+    label_aligned(label, gui_label_size_get());
     ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(2, 2));
     ImGui::BeginGroup();
     ImGui::PushButtonRepeat(true);
@@ -1259,7 +1288,7 @@ bool gui_color_small_conditional_label(const char *label, uint8_t color[4], bool
     
     ImGui::PushID(label);
     if (show_label) {
-        label_aligned(label, LABEL_SIZE);
+        label_aligned(label, gui_label_size_get());
     }
     ret = ImGui::ColorEdit4("", colorf, ImGuiColorEditFlags_NoInputs);
     ImGui::PopID();
@@ -1306,7 +1335,7 @@ bool gui_color_opacity(uint8_t color[4]) {
 bool gui_checkbox(const char *label, bool *v, const char *hint)
 {
     bool ret;
-    label_aligned("", LABEL_SIZE);
+    label_aligned("", gui_label_size_get());
     ImGui::PushStyleColor(ImGuiCol_FrameBg, COLOR(CHECKBOX, INNER, false));
     ImGui::PushStyleColor(ImGuiCol_CheckMark, COLOR(CHECKBOX, ITEM, false));
     ret = ImGui::Checkbox(label, v);

--- a/src/gui.h
+++ b/src/gui.h
@@ -105,7 +105,9 @@ typedef struct gui_icon_info
 } gui_icon_info_t;
 
 bool gui_icons_grid(int nb, const gui_icon_info_t *icons, int *current);
-
+float gui_label_size_get(void);
+void gui_label_size_push(float v);
+void gui_label_size_pop(void);
 bool gui_tab(const char *label, int icon, bool *v);
 void gui_tooltip_if_hovered(const char *info);
 bool gui_checkbox(const char *label, bool *v, const char *hint);

--- a/src/tools/color_picker.c
+++ b/src/tools/color_picker.c
@@ -48,6 +48,7 @@ int tool_color_picker_iter(tool_t *tool, const painter_t *painter,
 static int gui(tool_t *tool)
 {
     tool_gui_color();
+    gui_section_end();
     return 0;
 }
 

--- a/src/tools/fuzzy_select.c
+++ b/src/tools/fuzzy_select.c
@@ -177,7 +177,14 @@ static int gui(tool_t *tool_)
     }
     if (gui_button("Fill", 1, 0)) {
         image_history_push(goxel.image);
-        volume_merge(volume, goxel.mask, MODE_OVER, goxel.painter.color);
+        volume_t *vol = volume_copy(goxel.mask);
+        float box[4][4] = MAT4_IDENTITY;
+        volume_get_box(goxel.mask, true, box);
+        int existing_mode = goxel.painter.mode;
+        goxel.painter.mode = MODE_PAINT;
+        volume_op(vol, &goxel.painter, box);
+        volume_merge(volume, vol, MODE_OVER, NULL);
+        goxel.painter.mode = existing_mode;
     }
     if (gui_button("Cut as new layer", 1, 0)) {
         image_history_push(goxel.image);

--- a/src/tools/fuzzy_select.c
+++ b/src/tools/fuzzy_select.c
@@ -147,6 +147,7 @@ static int gui(tool_t *tool_)
     if (gui_checkbox("Use color", &use_color, "Stop at different color")) {
         tool->threshold = use_color ? 0 : 255;
     }
+    gui_checkbox("Entire layer", &tool->global, "If unchecked, fuzzy will only select connected voxels; if checked, it will select any across the current layer");
     if (use_color) {
         gui_input_int("Threshold", &tool->threshold, 1, 254);
     }
@@ -160,8 +161,6 @@ static int gui(tool_t *tool_)
     }
 
     tool_gui_mask_mode();
-
-    gui_checkbox("Global", &tool->global, "If unchecked, fuzzy will only select connected voxels; if checked, it will select any across the current layer");
 
     if (volume_is_empty(goxel.mask))
         return 0;

--- a/src/tools/fuzzy_select.c
+++ b/src/tools/fuzzy_select.c
@@ -21,10 +21,55 @@
 typedef struct {
     tool_t tool;
     int threshold;
+    bool global;
     struct {
         gesture3d_t click;
     } gestures;
 } tool_fuzzy_select_t;
+
+
+static bool within_threshold(tool_fuzzy_select_t *tool, uint8_t v0[4], uint8_t v1[4]) {
+    if (!v0[3] || !v1[3]) return false;
+
+    int diff = max3(abs(v0[0] - v1[0]), abs(v0[1] - v1[1]), abs(v0[2] - v1[2]));
+    return diff <= tool->threshold;
+}
+
+static void volume_global_select(volume_t *volume, const int curs_pos[3], tool_fuzzy_select_t *tool, volume_t *selection) {
+    
+    uint8_t color_at_curs[4];
+    uint8_t current_color[4];
+    int pos[3];
+    volume_iterator_t iter;
+    volume_accessor_t volume_accessor, selection_accessor;
+    volume_clear(selection);
+
+    volume_accessor = volume_get_accessor(volume);
+    selection_accessor = volume_get_accessor(selection);
+
+    // Always include the voxel under cursor
+    volume_get_at(volume, &volume_accessor, curs_pos, color_at_curs);
+    if (color_at_curs[3] == 0) {
+        //LOG_D("No color under cursor");
+        return;
+    } else {
+        //LOG_D("Color under cursor: %i / %i / %i / %i", color_at_curs[0], color_at_curs[1], color_at_curs[2], color_at_curs[3]);
+    }
+    volume_set_at(selection, &selection_accessor, curs_pos, (uint8_t[]){255, 255, 255, 255});
+
+    // Iterate through the entire volume
+    iter = volume_get_iterator(volume, VOLUME_ITER_VOXELS | VOLUME_ITER_SKIP_EMPTY);
+    while (volume_iter(&iter, pos)) {
+        volume_get_at(volume, &volume_accessor, pos, current_color);
+        if (current_color[3] != 0) {
+            //LOG_D("Pos %i / %i / %i", pos[0], pos[1], pos[2]);
+        } else {
+            continue;
+        }
+        bool set = within_threshold(tool, color_at_curs, current_color);
+        volume_set_at(selection, &selection_accessor, pos, (uint8_t[]){255, 255, 255, set ? 255 : 0});
+    }
+}
 
 static int select_cond(void *user, const volume_t *volume,
                        const int base_pos[3],
@@ -33,14 +78,11 @@ static int select_cond(void *user, const volume_t *volume,
 {
     tool_fuzzy_select_t *tool = (void*)user;
     uint8_t v0[4], v1[4];
-    int d;
 
     volume_get_at(volume, volume_accessor, base_pos, v0);
     volume_get_at(volume, volume_accessor, new_pos, v1);
-    if (!v0[3] || !v1[3]) return 0;
 
-    d = max3(abs(v0[0] - v1[0]), abs(v0[1] - v1[1]), abs(v0[2] - v1[2]));
-    return d <= tool->threshold ? 255 : 0;
+    return within_threshold(tool, v0, v1) ? 255 : 0;
 }
 
 static int on_click(gesture3d_t *gest, void *user)
@@ -55,7 +97,11 @@ static int on_click(gesture3d_t *gest, void *user)
     pi[1] = floor(curs->pos[1]);
     pi[2] = floor(curs->pos[2]);
     sel = volume_new();
-    volume_select(volume, pi, select_cond, tool, sel);
+    if (!tool->global) {
+        volume_select(volume, pi, select_cond, tool, sel);
+    } else {
+        volume_global_select(volume, pi, tool, sel);
+    }
     if (goxel.mask == NULL) goxel.mask = volume_new();
     volume_merge(goxel.mask, sel, goxel.mask_mode ?: MODE_REPLACE, NULL);
     volume_delete(sel);
@@ -115,11 +161,15 @@ static int gui(tool_t *tool_)
 
     tool_gui_mask_mode();
 
+    gui_checkbox("Global", &tool->global, "If unchecked, fuzzy will only select connected voxels; if checked, it will select any across the current layer");
+
     if (volume_is_empty(goxel.mask))
         return 0;
 
     volume_t *volume = goxel.image->active_layer->volume;
 
+    tool_gui_color();
+    gui_section_end();
     gui_group_begin(NULL);
     if (gui_button("Delete blocks", 1, 0)) {
         image_history_push(goxel.image);

--- a/src/tools/line.c
+++ b/src/tools/line.c
@@ -182,6 +182,7 @@ static int gui(tool_t *tool)
     tool_gui_radius();
     tool_gui_smoothness();
     tool_gui_color();
+    gui_section_end();
     tool_gui_snap();
     tool_gui_shape(NULL);
     tool_gui_symmetry();

--- a/src/tools/placer.c
+++ b/src/tools/placer.c
@@ -22,7 +22,8 @@
 
 #define BOOL_STR(b) ((b) ? "true" : "false")
 
-static file_format_t *g_current = NULL;
+static file_format_t *ff_import_current = NULL;
+static file_format_t *ff_export_current = NULL;
 
 typedef struct {
     tool_t tool;
@@ -277,19 +278,28 @@ static int iter(tool_t *tool, const painter_t *painter,
     return tool->state;
 }
 
-static const char *make_label(const file_format_t *f, char *buf, int len)
+static const char *make_label(const file_format_t *f, char *buf, int len, char *id)
 {
     const char *ext = f->exts[0] + 1;
-    snprintf(buf, len, "%s (%s)", f->name, ext);
+    snprintf(buf, len, "%s (%s)##%s", f->name, ext, id);
     return buf;
 }
 
-static void on_format(void *user, file_format_t *f)
+static void on_import_format(void *user, file_format_t *f)
 {
     char label[128];
-    make_label(f, label, sizeof(label));
-    if (gui_combo_item(label, f == g_current)) {
-        g_current = f;
+    make_label(f, label, sizeof(label), "import");
+    if (gui_combo_item(label, f == ff_import_current)) {
+        ff_import_current = f;
+    }
+}
+
+static void on_export_format(void *user, file_format_t *f)
+{
+    char label[128];
+    make_label(f, label, sizeof(label), "export");
+    if (gui_combo_item(label, f == ff_export_current)) {
+        ff_export_current = f;
     }
 }
 
@@ -318,7 +328,7 @@ static void on_file_import(const char *path, const char *file_name, const file_f
     past = calloc(1, sizeof(*past));
     *past = (past_import_t) {
         .path = path,
-        .file_name = file_name,
+        .file_name = strdup(file_name),
         .format = format,
     };
 
@@ -332,6 +342,7 @@ static void on_file_import(const char *path, const char *file_name, const file_f
         DL_DELETE(past_files, f);
     }
 
+    LOG_D("On file import: %s / %s / %s", past->path, past->file_name, past->format->name);
     DL_APPEND(past_files, past);
 }
 
@@ -351,6 +362,7 @@ static void placer_acquire_selection() {
 
     // Use the mask (from fuzzy select) if there
     if (!volume_is_empty(goxel.mask)) {
+        LOG_D("Acquired selection from fuzzy mask");
         volume_merge(copy, goxel.mask, MODE_INTERSECT, NULL);
     } else {
         // Otherwise, use the selection box
@@ -398,29 +410,49 @@ static int gui(tool_t *tool)
         gui_section_end();
     }
 
-    // Browse files
-    char label[128];
-    gui_text("Import as");
-    if (!g_current) g_current = file_formats_import_to_volume; // First one.
+    if(gui_section_begin("Import as", true)) {
+        char label[128];
+        if (!ff_import_current) ff_import_current = file_formats_import_to_volume; // First one.
 
-    make_label(g_current, label, sizeof(label));
-    if (gui_combo_begin("Import as", label)) {
-        file_format_iter("v", NULL, on_format);
-        gui_combo_end();
-    }
+        make_label(ff_import_current, label, sizeof(label), "placerimport");
+        if (gui_combo_begin("Import as##plcaerimport", label)) {
+            file_format_iter("v", NULL, on_import_format);
+            gui_combo_end();
+        }
 
-    if (g_current->import_gui)
-        g_current->import_gui(g_current);
+        if (ff_import_current->import_gui)
+            ff_import_current->import_gui(ff_import_current);
 
-    if (gui_button("Import", 1, 0)) {
-        reset(placer);
-        goxel_import_file_to_volume(NULL, g_current->name, placer->imported_volume, on_file_import);
-        post_import(placer);
-    }
-    
-    if (gui_button("Reset", 1, 0)) {
-        reset(placer);
-    }
+        if (gui_button("Import", 1, 0)) {
+            reset(placer);
+            goxel_import_file_to_volume(NULL, ff_import_current->name, placer->imported_volume, on_file_import);
+            post_import(placer);
+        }
+        
+        if (gui_button("Reset", 1, 0)) {
+            reset(placer);
+        }
+    } gui_section_end();
+
+    if (gui_section_begin("Export as", GUI_SECTION_COLLAPSABLE_CLOSED)) {
+        char label[128];
+        if (!ff_export_current) ff_export_current = file_formats_export_to_volume; // First one.
+
+        make_label(ff_export_current, label, sizeof(label), "export");
+        if (gui_combo_begin("Export as##placerexport", label)) {
+            file_format_iter("t", NULL, on_export_format);
+            gui_combo_end();
+        }
+
+        if (ff_export_current->export_gui)
+            ff_export_current->export_gui(ff_export_current);
+        
+        if (gui_button("Export placer content", -1, 0)) {
+            const char* path = sys_get_save_path("", ff_export_current->exts, ff_export_current->exts_desc);
+            ff_export_current->export_volume_func(ff_export_current, placer->imported_volume, path);
+            on_file_import(path, get_file_name_from_path(path), ff_export_current);
+        }
+    } gui_section_end();
 
     tool_gui_snap();
     

--- a/src/tools/rect_select.c
+++ b/src/tools/rect_select.c
@@ -113,15 +113,43 @@ static int iter(tool_t *tool_, const painter_t *painter,
     return tool->tool.state;
 }
 
+static layer_t *cut_as_new_layer(image_t *img, layer_t *layer,
+                                 const volume_t *mask)
+{
+    layer_t *new_layer;
+
+    new_layer = image_duplicate_layer(img, layer);
+    volume_merge(new_layer->volume, mask, MODE_INTERSECT, NULL);
+    volume_merge(layer->volume, mask, MODE_SUB, NULL);
+    return new_layer;
+}
+
 static int gui(tool_t *tool_)
 {
     tool_gui_mask_mode();
 
     gui_group_begin(NULL);
-    gui_action_button(ACTION_reset_selection, "Reset", 1.0);
-    gui_action_button(ACTION_layer_clear, "Clear", 1.0);
-    gui_action_button(ACTION_fill_selection_box, "Fill", 1.0);
-    gui_action_button(ACTION_cut_as_new_layer, "Cut as new layer", 1.0);
+    volume_t *volume = goxel.image->active_layer->volume;
+    if (!volume_is_empty(goxel.mask)) {
+        gui_group_begin(NULL);
+        if (gui_button("Reset", 1, 0)) {
+            goxel.mask = volume_new();
+        }
+        gui_group_end();
+    }
+    if (gui_button("Delete blocks", 1, 0)) {
+        image_history_push(goxel.image);
+        volume_merge(volume, goxel.mask, MODE_SUB, NULL);
+    }
+    if (gui_button("Fill", 1, 0)) {
+        image_history_push(goxel.image);
+        volume_merge(volume, goxel.mask, MODE_OVER, goxel.painter.color);
+    }
+    if (gui_button("Cut as new layer", 1, 0)) {
+        image_history_push(goxel.image);
+        cut_as_new_layer(goxel.image, goxel.image->active_layer,
+                         goxel.mask);
+    }
     gui_group_end();
 
     return 0;

--- a/src/volume_utils.c
+++ b/src/volume_utils.c
@@ -314,6 +314,35 @@ void get_color_beneath(int start_pos[3], uint8_t* out) {
     memcpy(out, color, 4);
 }
 
+void apply_noise_if_applicable(const painter_t* painter, float global_p[3], uint8_t col[4]) {
+    if (painter->noise_enabled != 0 && painter->noise_intensity != 0 && painter->noise_coverage != 0) {
+        float noise_value = uniform_noise(global_p[0], global_p[1], global_p[2]);
+        int noise_col[3];
+        noise_col[0] = col[0];
+        noise_col[1] = col[1];
+        noise_col[2] = col[2];
+        if (noise_value < (float)painter->noise_coverage / 100.0f) {
+            blend_with_noise_alpha(noise_col, noise_value, (float)painter->noise_intensity, (float)painter->noise_saturation, noise_col);
+            col[0] = noise_col[0];
+            col[1] = noise_col[1];
+            col[2] = noise_col[2];
+        }
+
+        // // Apply coverage: skip voxels outside the noise coverage range
+        // if (noise_value > (float)painter->noise_coverage / 100.0f) {
+        //     //LOG_D("Skipped");
+        // } else {
+        //     // Adjust noise intensity and saturation
+        //     float noise_factor = (float)painter->noise_intensity / 100.0f * noise_value;
+        //     //LOG_D("Noise factor: %f", noise_factor);
+        //     col[0] = (uint8_t)clamp(col[0] + noise_factor * painter->noise_saturation, 0.0f, 255.0f);
+        //     col[1] = (uint8_t)clamp(col[1] + noise_factor * painter->noise_saturation, 0.0f, 255.0f);
+        //     col[2] = (uint8_t)clamp(col[2] + noise_factor * painter->noise_saturation, 0.0f, 255.0f);
+        //     //col[3] = (uint8_t)clamp(col[3] * (1.0f - noise_factor), 0.0f, 255.0f);
+        // }
+    }
+}
+
 void volume_op(volume_t *volume, const painter_t *painter, const float box[4][4])
 {   
     // box[1][0] = 1/2 x size
@@ -454,32 +483,8 @@ void volume_op(volume_t *volume, const painter_t *painter, const float box[4][4]
         //         //col[3] = (uint8_t)clamp(col[3] * (1.0f - noise_factor), 0.0f, 255.0f);
         //     }
         // }
-        if (painter->noise_enabled != 0 && painter->noise_intensity != 0 && painter->noise_coverage != 0) {
-            float noise_value = uniform_noise(global_p[0], global_p[1], global_p[2]);
-            int noise_col[3];
-            noise_col[0] = col[0];
-            noise_col[1] = col[1];
-            noise_col[2] = col[2];
-            if (noise_value < (float)painter->noise_coverage / 100.0f) {
-                blend_with_noise_alpha(noise_col, noise_value, (float)painter->noise_intensity, (float)painter->noise_saturation, noise_col);
-                col[0] = noise_col[0];
-                col[1] = noise_col[1];
-                col[2] = noise_col[2];
-            }
-
-            // // Apply coverage: skip voxels outside the noise coverage range
-            // if (noise_value > (float)painter->noise_coverage / 100.0f) {
-            //     //LOG_D("Skipped");
-            // } else {
-            //     // Adjust noise intensity and saturation
-            //     float noise_factor = (float)painter->noise_intensity / 100.0f * noise_value;
-            //     //LOG_D("Noise factor: %f", noise_factor);
-            //     col[0] = (uint8_t)clamp(col[0] + noise_factor * painter->noise_saturation, 0.0f, 255.0f);
-            //     col[1] = (uint8_t)clamp(col[1] + noise_factor * painter->noise_saturation, 0.0f, 255.0f);
-            //     col[2] = (uint8_t)clamp(col[2] + noise_factor * painter->noise_saturation, 0.0f, 255.0f);
-            //     //col[3] = (uint8_t)clamp(col[3] * (1.0f - noise_factor), 0.0f, 255.0f);
-            // }
-        }
+        apply_noise_if_applicable(painter, global_p, col);
+        
         memcpy(c, col, 4);
 
         c[3] *= v;


### PR DESCRIPTION
- "simple shadows" filter which just does a straight-down shadow of objects from other visible layers, onto the current layer
- "coords" filter which spits out coords of the selection box into the console
- Windows build updates thanks to NexusKorthos https://github.com/guillaumechereau/goxel/pull/449
- Default PTZ camera updated so that the orbit pivot is the block you have under the cursor at the start of rotation, rather than an arbitrary distance away with thanks to tatelax https://github.com/guillaumechereau/goxel/pull/439/files
- Placer can now export its content to a file
- Label size push/pop for more control over label width
- Some actions now contribute to the history undo/redo when they didn't before (various 'fill' actions)
- Fuzzy select now has an "Entire layer" checkbox which switches out the default neighbour-based selection with a check across the entire of the current layer
- Fuzzy select's "fill" option now respects the noise settings